### PR TITLE
Update ProofpointTAP_pollingconfig.json with a different time parameters

### DIFF
--- a/Solutions/ProofPointTap/Data Connectors/ProofpointTAP_CCP/ProofpointTAP_pollingconfig.json
+++ b/Solutions/ProofPointTap/Data Connectors/ProofpointTAP_CCP/ProofpointTAP_pollingconfig.json
@@ -18,14 +18,21 @@
             "Password": "{{password}}"
         },
         "request": {
-            "apiEndpoint": "https://tap-api-v2.proofpoint.com/v2/siem/clicks/blocked?format=json",
+            "apiEndpoint": "https://tap-api-v2.proofpoint.com/v2/siem/clicks/blocked",
             "rateLimitQPS": 10,
             "queryWindowInMin": 5,
             "httpMethod": "GET",
             "retryCount": 3,
             "timeoutInSeconds": 60,
-            "startTimeAttributeName": "sinceTime",
             "queryTimeFormat": "yyyy-MM-ddTHH:mm:ssZ"
+            "queryParameters": {
+                "interval": "{_QueryWindowStartTime}/{_QueryWindowEndTime}",
+                "format": "json"
+            },
+            "headers": {
+                "Accept": "application/json",
+                "Authorization": "[[concat('Basic ', base64(concat(parameters('username'),':',parameters('password'))))]"
+            }
         },
         "response": {
             "eventsJsonPaths": [
@@ -56,14 +63,21 @@
             "Password": "{{password}}"
         },
         "request": {
-            "apiEndpoint": "https://tap-api-v2.proofpoint.com/v2/siem/messages/blocked?format=json",
+            "apiEndpoint": "https://tap-api-v2.proofpoint.com/v2/siem/messages/blocked",
             "rateLimitQPS": 10,
             "queryWindowInMin": 5,
             "httpMethod": "GET",
             "retryCount": 3,
             "timeoutInSeconds": 60,
-            "startTimeAttributeName": "sinceTime",
-            "queryTimeFormat": "yyyy-MM-ddTHH:mm:ssZ"
+            "queryTimeFormat": "yyyy-MM-ddTHH:mm:ssZ",
+            "queryParameters": {
+                "interval": "{_QueryWindowStartTime}/{_QueryWindowEndTime}",
+                "format": "json"
+            },
+            "headers": {
+                "Accept": "application/json",
+                "Authorization": "[[concat('Basic ', base64(concat(parameters('username'),':',parameters('password'))))]"
+            }
         },
         "response": {
             "eventsJsonPaths": [
@@ -94,14 +108,21 @@
             "Password": "{{password}}"
         },
         "request": {
-            "apiEndpoint": "https://tap-api-v2.proofpoint.com/v2/siem/clicks/permitted?format=json",
+            "apiEndpoint": "https://tap-api-v2.proofpoint.com/v2/siem/clicks/permitted",
             "rateLimitQPS": 10,
             "queryWindowInMin": 5,
             "httpMethod": "GET",
             "retryCount": 3,
             "timeoutInSeconds": 60,
-            "startTimeAttributeName": "sinceTime",
-            "queryTimeFormat": "yyyy-MM-ddTHH:mm:ssZ"
+            "queryTimeFormat": "yyyy-MM-ddTHH:mm:ssZ",
+            "queryParameters": {
+                "interval": "{_QueryWindowStartTime}/{_QueryWindowEndTime}",
+                "format": "json"
+            },
+            "headers": {
+                "Accept": "application/json",
+                "Authorization": "[[concat('Basic ', base64(concat(parameters('username'),':',parameters('password'))))]"
+            }
         },
         "response": {
             "eventsJsonPaths": [
@@ -132,14 +153,21 @@
             "Password": "{{password}}"
         },
         "request": {
-            "apiEndpoint": "https://tap-api-v2.proofpoint.com/v2/siem/messages/delivered?format=json",
+            "apiEndpoint": "https://tap-api-v2.proofpoint.com/v2/siem/messages/delivered",
             "rateLimitQPS": 10,
             "queryWindowInMin": 5,
             "httpMethod": "GET",
             "retryCount": 3,
             "timeoutInSeconds": 60,
-            "startTimeAttributeName": "sinceTime",
-            "queryTimeFormat": "yyyy-MM-ddTHH:mm:ssZ"
+            "queryTimeFormat": "yyyy-MM-ddTHH:mm:ssZ",
+            "queryParameters": {
+                "interval": "{_QueryWindowStartTime}/{_QueryWindowEndTime}",
+                "format": "json"
+            },
+            "headers": {
+                "Accept": "application/json",
+                "Authorization": "[[concat('Basic ', base64(concat(parameters('username'),':',parameters('password'))))]"
+            }
         },
         "response": {
             "eventsJsonPaths": [


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updated CCF RestApiPoller to utilize different time parameters (interval) instead of sinceTime
   - Authorization headers in the API call
   Reason for Change(s):
   - Previous time parameter values resulted in incomplete data being retrieved

   Testing Completed:
   - Yes



